### PR TITLE
fix: Avoid removing node_modules during clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.prod.js",
-    "clean": "rm -rf ./build && rm -rf ./node_modules && rm -rf ./coverage && rm -rf ./dist",
+    "clean": "rm -rf ./build && rm -rf ./coverage && rm -rf ./dist",
     "documentation": "typedoc src/ --gitRemote upstream --gitRevision master",
     "start": "webpack-dev-server --config webpack.dev.js",
     "server": "npm run start",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Avoid removing node_modules during clean. During publish, it cleans but unable to run pre-publish script since node_modules have been removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
