### PR TITLE
fix: Update docs path for github page documentation website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,8 +21,8 @@
 title: Diagram Maker
 description: >- # this means to ignore newlines until "baseurl:"
   A library to display an interactive editor for any graph-like data.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/diagram-maker" # the subpath of your site, e.g. /blog
+url: "https://awslabs.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 markdown: GFM
 
 # Build settings


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update docs path for github page documentation website. 

Documentation links dont seem to be working on the github pages documentation website due to missing baseUrl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
