### PR TITLE
docs: Updating initialization example to use named export instead of …

### DIFF
--- a/docs/usage/initialization.md
+++ b/docs/usage/initialization.md
@@ -6,7 +6,7 @@ sort: 2
 
 ```javascript
 
-import DiagramMaker from 'diagram-maker';
+import { DiagramMaker } from 'diagram-maker';
 
 const diagramMaker = new DiagramMaker(
   container,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/diagram-maker/issues/13

*Description of changes:*
Updating initialization example to use named export instead of default export

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
