### PR TITLE
feature(edge): Add hover action to an edge

### DIFF
--- a/src/service/ui/UIEventManager.ts
+++ b/src/service/ui/UIEventManager.ts
@@ -27,7 +27,9 @@ export enum MouseClickEventType {
 }
 
 export enum MouseMoveEventType {
-  MOUSE_MOVE = 'mousemove'
+  MOUSE_MOVE = 'mousemove',
+  MOUSE_OVER = 'mouseover',
+  MOUSE_OUT = 'mouseout'
 }
 
 export enum WheelEventType {
@@ -58,8 +60,8 @@ export enum KeyboardEventType {
 }
 
 export type EventType = ContainerEventType | DestroyEventType |
-            MouseMoveEventType | MouseClickEventType | WheelEventType |
-            WindowEventType | DragEventType | KeyboardEventType | DropEventType;
+  MouseMoveEventType | MouseClickEventType | WheelEventType |
+  WindowEventType | DragEventType | KeyboardEventType | DropEventType;
 
 export const MouseClickEvent = { ...MouseClickEventType };
 export const MouseMoveEvent = { ...MouseMoveEventType };
@@ -79,7 +81,7 @@ export const Event = {
   ...KeyboardEvent
 };
 
-export type EventListener  = (event: Event) => void;
+export type EventListener = (event: Event) => void;
 
 export interface EventListenerRef {
   eventType: EventType;
@@ -89,7 +91,7 @@ export interface EventListenerRef {
 
 const { MOUSE_DOWN, MOUSE_UP, LEFT_CLICK, RIGHT_CLICK } = MouseClickEventType;
 const { MOUSE_WHEEL } = WheelEventType;
-const { MOUSE_MOVE } = MouseMoveEventType;
+const { MOUSE_MOVE, MOUSE_OVER, MOUSE_OUT } = MouseMoveEventType;
 const { RESIZE } = WindowEventType;
 const { DRAG, DRAG_START, DRAG_END } = DragEventType;
 const { DROP, DRAG_OVER, DRAG_ENTER, DRAG_LEAVE } = DropEventType;
@@ -115,6 +117,8 @@ export default class UIEventManager {
     this.listenFor(MOUSE_UP, UIEventNormalizer.normalizeMouseUpEvent, window);
     this.listenFor(MOUSE_MOVE, UIEventNormalizer.normalizeMouseMoveEvent, window);
     this.listenFor(RIGHT_CLICK, UIEventNormalizer.normalizeRightClickEvent, window);
+    this.listenFor(MOUSE_OVER, UIEventNormalizer.normalizeMouseOverEvent, window);
+    this.listenFor(MOUSE_OUT, UIEventNormalizer.normalizeMouseOutEvent, window);
 
     // Wheel
     this.listenFor(MOUSE_WHEEL, UIEventNormalizer.normalizeWheelEvent);

--- a/src/service/ui/UIEventNormalizer.spec.ts
+++ b/src/service/ui/UIEventNormalizer.spec.ts
@@ -19,6 +19,10 @@ const contextOffset = {
 const context = document.body;
 
 describe('UIEventNormalizer', () => {
+  beforeEach(() => {
+    jest.spyOn(UITargetNormalizer, 'normalizeTarget').mockRestore();
+  });
+
   describe('getRequiredAttribute', () => {
     it('returns data-event-target for RIGHT_CLICK', () => {
       expect(getRequiredAttribute(MouseClickEventType.RIGHT_CLICK)).toBe(EventAttribute.DATA_EVENT_TARGET);
@@ -30,6 +34,14 @@ describe('UIEventNormalizer', () => {
 
     it('returns data-event-target for MOUSE_UP', () => {
       expect(getRequiredAttribute(MouseClickEventType.MOUSE_UP)).toBe(EventAttribute.DATA_EVENT_TARGET);
+    });
+
+    it('returns data-event-target for MOUSE_OVER', () => {
+      expect(getRequiredAttribute(MouseMoveEventType.MOUSE_OVER)).toBe(EventAttribute.DATA_EVENT_TARGET);
+    });
+
+    it('returns data-event-target for MOUSE_OUT', () => {
+      expect(getRequiredAttribute(MouseMoveEventType.MOUSE_OUT)).toBe(EventAttribute.DATA_EVENT_TARGET);
     });
 
     it('returns data-event-target for MOUSE_DRAG', () => {
@@ -218,6 +230,114 @@ describe('UIEventNormalizer', () => {
 
         expect(normalizedEvent.button).toBe(button);
       });
+    });
+  });
+
+  describe('normalizeMouseOverEvent', () => {
+    let event: MouseEvent;
+    const type = MouseMoveEventType.MOUSE_OVER;
+
+    beforeEach(() => {
+      event = new MouseEvent(type);
+    });
+
+    it('only triggers if it can find a target with data-event-target', () => {
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent).toBe(undefined);
+    });
+
+    it('normalizes the type', () => {
+      const target = document.createElement('div');
+
+      target.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      Object.defineProperty(event, 'target', { value: target, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOverEvent(event);
+
+      expect(normalizedEvent.type).toBe(type);
+    });
+
+    it('attaches the original event', () => {
+      const target = document.createElement('div');
+
+      target.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      Object.defineProperty(event, 'target', { value: target, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOverEvent(event);
+
+      expect(normalizedEvent.originalEvent).toBe(event);
+    });
+
+    it('normalizes the target', () => {
+      const originalTarget = document.createElement('div');
+      const id = '1234';
+      const normalizeTargetSpy = jest.spyOn(UITargetNormalizer, 'normalizeTarget');
+
+      originalTarget.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      originalTarget.setAttribute('data-id', id);
+      originalTarget.setAttribute('data-type', type);
+      Object.defineProperty(event, 'target', { value: originalTarget, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent.target).toEqual({ id, originalTarget, type });
+      expect(normalizeTargetSpy).toHaveBeenCalledTimes(1);
+      expect(normalizeTargetSpy).toHaveBeenCalledWith(originalTarget);
+    });
+  });
+
+  describe('normalizeMouseOutEvent', () => {
+    let event: MouseEvent;
+    const type = MouseMoveEventType.MOUSE_OUT;
+
+    beforeEach(() => {
+      event = new MouseEvent(type);
+    });
+
+    it('only triggers if it can find a target with data-event-target', () => {
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent).toBe(undefined);
+    });
+
+    it('normalizes the type', () => {
+      const target = document.createElement('div');
+
+      target.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      Object.defineProperty(event, 'target', { value: target, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent.type).toBe(type);
+    });
+
+    it('attaches the original event', () => {
+      const target = document.createElement('div');
+
+      target.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      Object.defineProperty(event, 'target', { value: target, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent.originalEvent).toBe(event);
+    });
+
+    it('normalizes the target', () => {
+      const originalTarget = document.createElement('div');
+      const id = '1234';
+      const normalizeTargetSpy = jest.spyOn(UITargetNormalizer, 'normalizeTarget');
+
+      originalTarget.setAttribute(EventAttribute.DATA_EVENT_TARGET, 'true');
+      originalTarget.setAttribute('data-id', id);
+      originalTarget.setAttribute('data-type', type);
+      Object.defineProperty(event, 'target', { value: originalTarget, writable: true });
+
+      const normalizedEvent: any = UIEventNormalizer.normalizeMouseOutEvent(event);
+
+      expect(normalizedEvent.target).toEqual({ id, originalTarget, type });
+      expect(normalizeTargetSpy).toHaveBeenCalledTimes(1);
+      expect(normalizeTargetSpy).toHaveBeenCalledWith(originalTarget);
     });
   });
 

--- a/src/state/ActionDispatcher.spec.ts
+++ b/src/state/ActionDispatcher.spec.ts
@@ -7,7 +7,13 @@ import ConfigService from 'diagramMaker/service/ConfigService';
 import Observer from 'diagramMaker/service/observer/Observer';
 import { DiagramMakerComponentsType } from 'diagramMaker/service/ui/types';
 import {
-  ContainerEventType, DragEventType, DropEventType, KeyboardEventType, MouseClickEventType, WheelEventType
+  ContainerEventType,
+  DragEventType,
+  DropEventType,
+  KeyboardEventType,
+  MouseClickEventType,
+  MouseMoveEventType,
+  WheelEventType
 } from 'diagramMaker/service/ui/UIEventManager';
 import { KeyboardCode } from 'diagramMaker/service/ui/UIEventNormalizer';
 import UITargetNormalizer from 'diagramMaker/service/ui/UITargetNormalizer';
@@ -38,6 +44,7 @@ const { DROP } = DropEventType;
 const { MOUSE_WHEEL } = WheelEventType;
 const { KEY_DOWN } = KeyboardEventType;
 const { DIAGRAM_MAKER_CONTAINER_UPDATE } = ContainerEventType;
+const { MOUSE_OUT, MOUSE_OVER } = MouseMoveEventType;
 
 const {
   NODE, EDGE, EDGE_BADGE, NODE_CONNECTOR, PANEL_DRAG_HANDLE, POTENTIAL_NODE, WORKSPACE
@@ -156,6 +163,38 @@ describe('ActionDispatcher', () => {
       observer.publish(LEFT_CLICK, { target });
       expect(handleWorkspaceClickSpy).toHaveBeenCalledTimes(1);
       expect(handleWorkspaceClickSpy).toHaveBeenCalledWith(store);
+    });
+  });
+
+  describe('handleMouseOver', () => {
+    [EDGE, EDGE_BADGE].forEach((type) => {
+      it(`calls handleMouseOver if type is DiagramMakerComponents.${type}`, () => {
+        initialize({ x: 200, y: 300 }, 2);
+
+        const handleEdgeMouseOverSpy = spyOn(EdgeActionHandlers, 'handleEdgeMouseOver');
+        const id = 1234;
+        const target = { id, type };
+
+        observer.publish(MOUSE_OVER, { target });
+        expect(handleEdgeMouseOverSpy).toHaveBeenCalledTimes(1);
+        expect(handleEdgeMouseOverSpy).toHaveBeenCalledWith(store, id);
+      });
+    });
+  });
+
+  describe('handleMouseOut', () => {
+    [EDGE, EDGE_BADGE].forEach((type) => {
+      it(`calls handleMouseOut if type is DiagramMakerComponents.${type}`, () => {
+        initialize({ x: 200, y: 300 }, 2);
+
+        const handleEdgeMouseOutSpy = spyOn(EdgeActionHandlers, 'handleEdgeMouseOut');
+        const id = 1234;
+        const target = { id, type };
+
+        observer.publish(MOUSE_OUT, { target });
+        expect(handleEdgeMouseOutSpy).toHaveBeenCalledTimes(1);
+        expect(handleEdgeMouseOutSpy).toHaveBeenCalledWith(store, id);
+      });
     });
   });
 

--- a/src/state/ActionDispatcher.ts
+++ b/src/state/ActionDispatcher.ts
@@ -24,13 +24,20 @@ import {
   NormalizedEvent,
   NormalizedKeyboardEvent,
   NormalizedMouseClickEvent,
+  NormalizedMouseHoverEvent,
   NormalizedMouseMoveEvent,
   NormalizedMouseScrollEvent,
   NormalizedWindowEvent
 } from 'diagramMaker/service/ui/UIEventNormalizer';
 import UITargetNormalizer from 'diagramMaker/service/ui/UITargetNormalizer';
 import {
-  handleEdgeClick, handleEdgeCreate, handleEdgeDrag, handleEdgeDragEnd, handleEdgeDragStart
+  handleEdgeClick,
+  handleEdgeCreate,
+  handleEdgeDrag,
+  handleEdgeDragEnd,
+  handleEdgeDragStart,
+  handleEdgeMouseOut,
+  handleEdgeMouseOver
 } from 'diagramMaker/state/edge/edgeActionDispatcher';
 import {
   handleHideContextMenu,
@@ -78,7 +85,7 @@ export default class ActionDispatcher<NodeType, EdgeType> {
 
   private subscribeToUIEvents() {
     const { LEFT_CLICK, RIGHT_CLICK, MOUSE_UP, MOUSE_DOWN } = MouseClickEventType;
-    const { MOUSE_MOVE } = MouseMoveEventType;
+    const { MOUSE_MOVE, MOUSE_OVER, MOUSE_OUT } = MouseMoveEventType;
     const { DRAG, DRAG_START, DRAG_END } = DragEventType;
     const { DROP, DRAG_ENTER, DRAG_LEAVE, DRAG_OVER } = DropEventType;
     const { MOUSE_WHEEL } = WheelEventType;
@@ -91,6 +98,8 @@ export default class ActionDispatcher<NodeType, EdgeType> {
     this.subscribeWithFilter(MOUSE_UP, this.handleMouseUp);
     this.subscribeWithFilter(MOUSE_DOWN, this.handleMouseDown);
     this.subscribeWithFilter(MOUSE_MOVE, this.handleMouseMove);
+    this.subscribeWithFilter(MOUSE_OVER, this.handleMouseOver);
+    this.subscribeWithFilter(MOUSE_OUT, this.handleMouseOut);
     this.subscribeWithFilter(DRAG, this.handleDrag);
     this.subscribeWithFilter(DRAG_START, this.handleDragStart);
     this.subscribeWithFilter(DRAG_ENTER, this.handleDragEnter);
@@ -139,6 +148,30 @@ export default class ActionDispatcher<NodeType, EdgeType> {
         break;
       case (DiagramMakerComponentsType.WORKSPACE):
         handleWorkspaceClick(this.store);
+        break;
+    }
+  }
+
+  private handleMouseOver = (event: NormalizedMouseHoverEvent): void => {
+    const { target } = event;
+    const { type, id } = target;
+
+    switch (type) {
+      case (DiagramMakerComponentsType.EDGE_BADGE):
+      case (DiagramMakerComponentsType.EDGE):
+        handleEdgeMouseOver(this.store, id);
+        break;
+    }
+  }
+
+  private handleMouseOut = (event: NormalizedMouseHoverEvent): void => {
+    const { target } = event;
+    const { type, id } = target;
+
+    switch (type) {
+      case (DiagramMakerComponentsType.EDGE_BADGE):
+      case (DiagramMakerComponentsType.EDGE):
+        handleEdgeMouseOut(this.store, id);
         break;
     }
   }

--- a/src/state/edge/edgeActionDispatcher.spec.ts
+++ b/src/state/edge/edgeActionDispatcher.spec.ts
@@ -5,7 +5,13 @@ import { v4 as uuid } from 'uuid';
 import { asMock } from 'diagramMaker/testing/testUtils';
 
 import {
-  handleEdgeClick, handleEdgeCreate, handleEdgeDrag, handleEdgeDragEnd, handleEdgeDragStart
+  handleEdgeClick,
+  handleEdgeCreate,
+  handleEdgeDrag,
+  handleEdgeDragEnd,
+  handleEdgeDragStart,
+  handleEdgeMouseOut,
+  handleEdgeMouseOver
 } from './edgeActionDispatcher';
 import { EdgeActionsType } from './edgeActions';
 
@@ -136,6 +142,40 @@ describe('edgeActionDispatcher', () => {
         payload: { id, src, dest },
         type: EdgeActionsType.EDGE_CREATE
       });
+    });
+  });
+
+  describe('handleEdgeMouseOver', () => {
+    it('dispatches an edge mouse over action', () => {
+      const edgeId = 'edge1';
+      handleEdgeMouseOver(store, edgeId);
+      expect(store.dispatch).toHaveBeenCalledWith({
+        payload: { id: edgeId },
+        type: EdgeActionsType.EDGE_MOUSE_OVER
+      });
+    });
+
+    it('dispatches nothing when id is absent', () => {
+      const edgeId = undefined;
+      handleEdgeMouseOver(store, edgeId);
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleEdgeMouseOut', () => {
+    it('dispatches an edge mouse out action', () => {
+      const edgeId = 'edge1';
+      handleEdgeMouseOut(store, edgeId);
+      expect(store.dispatch).toHaveBeenCalledWith({
+        payload: { id: edgeId },
+        type: EdgeActionsType.EDGE_MOUSE_OUT
+      });
+    });
+
+    it('dispatches nothing when id is absent', () => {
+      const edgeId = undefined;
+      handleEdgeMouseOut(store, edgeId);
+      expect(store.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/state/edge/edgeActionDispatcher.ts
+++ b/src/state/edge/edgeActionDispatcher.ts
@@ -4,7 +4,14 @@ import { v4 as uuid } from 'uuid';
 import { DiagramMakerData, Position } from 'diagramMaker/state/types';
 
 import {
-  CreateEdgeAction, DragEdgeAction, DragEndEdgeAction, DragStartEdgeAction, EdgeActionsType, SelectEdgeAction
+  CreateEdgeAction,
+  DragEdgeAction,
+  DragEndEdgeAction,
+  DragStartEdgeAction,
+  EdgeActionsType,
+  MouseOutAction,
+  MouseOverAction,
+  SelectEdgeAction
 } from './edgeActions';
 
 function createDragStartEdgeAction(id: string, position: Position): DragStartEdgeAction {
@@ -37,6 +44,20 @@ function createNewEdgeAction<EdgeType>(id: string, src: string, dest: string): C
 function createSelectEdgeAction(id: string): SelectEdgeAction {
   return {
     type: EdgeActionsType.EDGE_SELECT,
+    payload: { id }
+  };
+}
+
+function createMouseOverEdgeAction(id: string): MouseOverAction {
+  return {
+    type: EdgeActionsType.EDGE_MOUSE_OVER,
+    payload: { id }
+  };
+}
+
+function createMouseOutEdgeAction(id: string): MouseOutAction {
+  return {
+    type: EdgeActionsType.EDGE_MOUSE_OUT,
     payload: { id }
   };
 }
@@ -89,5 +110,23 @@ export function handleEdgeClick<NodeType, EdgeType>(
 ) {
   if (id) {
     store.dispatch(createSelectEdgeAction(id));
+  }
+}
+
+export function handleEdgeMouseOver<NodeType, EdgeType>(
+  store: Store<DiagramMakerData<NodeType, EdgeType>>,
+  id: string | undefined
+) {
+  if (id) {
+    store.dispatch(createMouseOverEdgeAction(id));
+  }
+}
+
+export function handleEdgeMouseOut<NodeType, EdgeType>(
+  store: Store<DiagramMakerData<NodeType, EdgeType>>,
+  id: string | undefined
+) {
+  if (id) {
+    store.dispatch(createMouseOutEdgeAction(id));
   }
 }

--- a/src/state/edge/edgeActions.ts
+++ b/src/state/edge/edgeActions.ts
@@ -14,7 +14,11 @@ export enum EdgeActionsType {
   /** Potential Edge drag */
   EDGE_DRAG_END = 'EDGE_DRAG_END',
   /** Potential Edge drag end */
-  EDGE_DRAG = 'EDGE_DRAG'
+  EDGE_DRAG = 'EDGE_DRAG',
+  /** Mouse enters edge */
+  EDGE_MOUSE_OVER = 'EDGE_MOUSE_OVER',
+  /** Mouse leaves edge */
+  EDGE_MOUSE_OUT = 'EDGE_MOUSE_OUT'
 }
 
 export const EdgeActions = {
@@ -79,5 +83,23 @@ export interface DragEdgeAction extends Action {
   };
 }
 
+/** Action fired when the mouse enters an edge */
+export interface MouseOverAction extends Action {
+  type: EdgeActionsType.EDGE_MOUSE_OVER;
+  payload: {
+    /** ID of the edge that is being hovered */
+    id: string;
+  };
+}
+
+/** Action fired when the mouse leaves an edge */
+export interface MouseOutAction extends Action {
+  type: EdgeActionsType.EDGE_MOUSE_OUT;
+  payload: {
+    /** ID of the edge that is being hovered */
+    id: string;
+  };
+}
+
 export type EdgeAction<EdgeType> = CreateEdgeAction<EdgeType> | SelectEdgeAction | DeleteEdgeAction |
-  DragStartEdgeAction | DragEndEdgeAction | DragEdgeAction ;
+  DragStartEdgeAction | DragEndEdgeAction | DragEdgeAction | MouseOverAction | MouseOutAction;


### PR DESCRIPTION
*Issue #84*

*Description of changes:*

- Listen to `mouseover` and `mouseout` events.
- Dispatch `EDGE_MOUSE_OVER` and `EDGE_MOUSE_OUT` actions, only if `mouseover` and `mouseout` events are associated with edge or edge badge elements.

---

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
