### PR TITLE
Add capability for multiple custom connectors to be connected to edges

### DIFF
--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -1,7 +1,7 @@
 import { DiagramMakerComponentsType } from 'diagramMaker/service/ui/types';
 import { ActionInterceptor } from 'diagramMaker/state/middleware';
 import {
-  DiagramMakerData, DiagramMakerEdge, DiagramMakerNode, DiagramMakerPanel, DiagramMakerPotentialNode, Size,
+  DiagramMakerData, DiagramMakerEdge, DiagramMakerNode, DiagramMakerPanel, DiagramMakerPotentialNode, Position, Size,
 } from 'diagramMaker/state/types';
 
 export enum ConnectorPlacementType {
@@ -26,6 +26,11 @@ export enum ConnectorPlacementType {
    * Does render connectors by default.
    */
   TOP_BOTTOM = 'TopBottom',
+  /**
+   * Edges start at positions that are configured by the node type.
+   * Doesn't render connectors by default.
+   */
+  CUSTOM = 'Custom',
 }
 
 export const ConnectorPlacement = {
@@ -236,6 +241,17 @@ export const Shape = {
   ...ShapeType,
 };
 
+export interface CustomConnectorType {
+  /**
+   * Position of the connector w.r.t to the parent node
+   */
+  readonly position: Position;
+  /**
+   * Unique identifier for the connector
+   */
+  readonly id: string;
+}
+
 /** Interface for storing configuration for a given node type */
 export interface DiagramMakerNodeTypeConfiguration {
   /**
@@ -256,6 +272,12 @@ export interface DiagramMakerNodeTypeConfiguration {
    * Used in conjunction with BOUNDARY connector placement.
    */
   shape?: ShapeType;
+  /**
+   * Used for specifying custom connector placements
+   */
+  customConnectorTypes?: {
+    [connectorTypeId: string]: CustomConnectorType;
+  }
 }
 
 export interface DiagramMakerConfig<NodeType, EdgeType> {
@@ -376,6 +398,11 @@ export default class ConfigService<NodeType, EdgeType> {
   public getShapeForNodeType = (typeId: string): ShapeType | undefined => {
     const typeConfig = this.getNodeTypeConfiguration(typeId);
     return typeConfig && typeConfig.shape;
+  };
+
+  public getCustomConnectorTypesForNodeType = (typeId: string): { [connectorId: string]: CustomConnectorType } => {
+    const typeConfig = this.getNodeTypeConfiguration(typeId);
+    return (typeConfig && typeConfig.customConnectorTypes) || {};
   };
 
   public getVisibleConnectorTypesForNodeType = (typeId: string): TypeForVisibleConnectorTypes | undefined => {

--- a/src/state/ActionDispatcher.spec.ts
+++ b/src/state/ActionDispatcher.spec.ts
@@ -502,6 +502,29 @@ describe('ActionDispatcher', () => {
       expect(handleEdgeDragStartSpy).toHaveBeenCalledWith(store, id, position);
     });
 
+    it('calls handleEdgeDragStart if type is DiagramMakerComponents.NODE_CONNECTOR and is a custom connector', () => {
+      initialize({ x: 0, y: 0 }, 1); // No workspace offet, scale of 1
+
+      const handleEdgeDragStartSpy = jest.spyOn(EdgeActionHandlers, 'handleEdgeDragStart');
+      const originalTarget = document.createElement('div');
+      const CONNECTOR_TYPE = 'CONNECTORTYPE';
+      originalTarget.setAttribute('data-connector-type', CONNECTOR_TYPE);
+      const target = {
+        id,
+        type: NODE_CONNECTOR,
+        originalTarget,
+      };
+      const position = { x: 200, y: 200 };
+      const event = {
+        position,
+        target,
+      };
+
+      observer.publish(DRAG_START, event);
+      expect(handleEdgeDragStartSpy).toHaveBeenCalledTimes(1);
+      expect(handleEdgeDragStartSpy).toHaveBeenCalledWith(store, id, position, CONNECTOR_TYPE);
+    });
+
     it('calls handlePotentialNodeDragStart if type is DiagramMakerComponents.POTENTIAL_NODE', () => {
       const position: Position = { x: 200, y: 200 };
       const offset: Position = { x: 50, y: 50 };

--- a/src/state/ActionDispatcher.ts
+++ b/src/state/ActionDispatcher.ts
@@ -256,7 +256,6 @@ export default class ActionDispatcher<NodeType, EdgeType> {
     const { type, id } = target;
     const editorMode = this.store.getState().editor.mode;
     const workspaceState = this.store.getState().workspace;
-
     switch (type) {
       case DiagramMakerComponentsType.WORKSPACE:
         if (editorMode === EditorMode.SELECT) {
@@ -272,14 +271,26 @@ export default class ActionDispatcher<NodeType, EdgeType> {
       case DiagramMakerComponentsType.NODE:
         handleNodeDragStart(this.store, id);
         break;
-      case (DiagramMakerComponentsType.NODE_CONNECTOR):
-        handleEdgeDragStart(
-          this.store,
-          id,
-          // No item offset, bc we want to draw dragged edges right at the tip of the pointer
-          ActionDispatcher.getNormalizedPositionOffsetInWorkspace(position, workspaceState),
-        );
+      case (DiagramMakerComponentsType.NODE_CONNECTOR): {
+        const connectorType = target?.originalTarget?.getAttribute('data-connector-type') || undefined;
+        if (connectorType) {
+          handleEdgeDragStart(
+            this.store,
+            id,
+            // No item offset, bc we want to draw dragged edges right at the tip of the pointer
+            ActionDispatcher.getNormalizedPositionOffsetInWorkspace(position, workspaceState),
+            connectorType,
+          );
+        } else {
+          handleEdgeDragStart(
+            this.store,
+            id,
+            // No item offset, bc we want to draw dragged edges right at the tip of the pointer
+            ActionDispatcher.getNormalizedPositionOffsetInWorkspace(position, workspaceState),
+          );
+        }
         break;
+      }
       case (DiagramMakerComponentsType.POTENTIAL_NODE):
         handlePotentialNodeDragStart(
           this.store,
@@ -342,7 +353,13 @@ export default class ActionDispatcher<NodeType, EdgeType> {
     switch (dropzone.type) {
       case (DiagramMakerComponentsType.NODE_CONNECTOR):
         if (type === DiagramMakerComponentsType.NODE_CONNECTOR) {
-          handleEdgeCreate(this.store, id, dropzone.id);
+          const srcConnectorType = target?.originalTarget?.getAttribute('data-connector-type') || undefined;
+          const destConnectorType = dropzone?.originalTarget?.getAttribute('data-connector-type') || undefined;
+          if (srcConnectorType || destConnectorType) {
+            handleEdgeCreate(this.store, id, dropzone.id, srcConnectorType, destConnectorType);
+          } else {
+            handleEdgeCreate(this.store, id, dropzone.id);
+          }
         }
         break;
       case (DiagramMakerComponentsType.WORKSPACE):

--- a/src/state/edge/edgeActions.ts
+++ b/src/state/edge/edgeActions.ts
@@ -55,6 +55,14 @@ export interface CreateEdgeAction<EdgeType> extends Action {
     dest: string;
     /** Consumer data that needs to be added for this newly created edge. */
     consumerData?: EdgeType;
+    /** Type of the connector where this edge originates.
+     *  Only applicable if the source node is of a node type that has custom connecter placements.
+     */
+    connectorSrcType?: string;
+    /** Type of the connector where this edge ends.
+     *  Only applicable if the destination node is of a node type that has custom connecter placements.
+     */
+    connectorDestType?: string;
   };
 }
 
@@ -66,6 +74,10 @@ export interface DragStartEdgeAction extends Action {
     id: string;
     /** Position where this potential edge terminates. Usually the cursor position. */
     position: Position;
+    /** Type of the connector where this potential edge originates.
+     *  Only applicable for node types that have custom connecter placements.
+     */
+    connectorSrcType?: string;
   };
 }
 

--- a/src/state/edge/edgeReducer.ts
+++ b/src/state/edge/edgeReducer.ts
@@ -29,7 +29,7 @@ export default function edgeReducer<NodeType, EdgeType>(
     case (EdgeActionsType.EDGE_CREATE):
       return produce(state, (draftState) => {
         const {
-          id, src, dest, consumerData: untypedConsumerData,
+          id, src, dest, consumerData: untypedConsumerData, connectorSrcType, connectorDestType,
         } = action.payload;
         const consumerData = untypedConsumerData as Draft<EdgeType>;
         const diagramMakerData = {};
@@ -39,6 +39,8 @@ export default function edgeReducer<NodeType, EdgeType>(
           diagramMakerData,
           id,
           src,
+          connectorSrcType,
+          connectorDestType,
         };
       });
     case (EdgeActionsType.EDGE_SELECT):

--- a/src/state/edge/potentialEdgeReducer.ts
+++ b/src/state/edge/potentialEdgeReducer.ts
@@ -17,6 +17,7 @@ export default function potentialEdgeReducer<NodeType, EdgeType>(
       return {
         position: action.payload.position,
         src: action.payload.id,
+        connectorSrcType: action.payload.connectorSrcType,
       };
     case (EdgeActionsType.EDGE_DRAG):
       return produce(state, (draftState) => {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -166,10 +166,18 @@ export interface DiagramMakerEdge<EdgeType> {
    */
   readonly src: string;
   /**
+   * References the src connector type (optional)
+   */
+  readonly connectorSrcType?: string;
+  /**
    * References the id for the node where this edge ends.
    * Leads to inconsistencies if this refers to a node that doesnt exist.
    */
   readonly dest: string;
+  /**
+   * References the dest connector type (optional)
+   */
+  readonly connectorDestType?: string;
   /** Contains edge data managed by diagram maker */
   readonly diagramMakerData: {
     /** Denotes whether the edge is selected */
@@ -199,6 +207,10 @@ export interface DiagramMakerPotentialEdge {
    * Usually refers to the cursor position relative to the workspace scale & position.
    */
   readonly position: Position;
+  /**
+   * References the src connector type (optional)
+   */
+  readonly connectorSrcType?: string;
 }
 
 /** Interface for storing state of a diagram maker panel */


### PR DESCRIPTION
This is an initial PR to get some eyes on the overall approach. Additional unit tests and integ tests are in progress, but I wanted to initiate the initial review on the high level changes. 

*Issue #, if available:* https://github.com/awslabs/diagram-maker/issues/67

*Description of changes:* 
- Add capability for edges to connect to individual custom connectors
- Allow consumer to configure the position of custom connectors


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
