### PR TITLE
fix broken documentation deployment GitHub action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,6 @@
 name: Build and Deploy Documentation
 
-run-name: \"Build and Deploy Documentation\" action iniated by ${{ github.actor }}
+run-name: Build and Deploy Documentation action iniated by ${{ github.actor }}
 
 on:
   push:
@@ -14,25 +14,26 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 19.x]
-
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - name: Install and Build using Node.js ${{ matrix.node-version }} 🔧
+      - name: Install Node.js 🔧
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-        run: |
-          npm i
-          npm run build
-          npm run documentation
+          node-version: 16
+
+      - name: Install Dependencies 🔩
+        run: npm install
+
+      - name: Build 👷‍
+        run: npm run build
+
+      - name: Build Documentation 📕
+        run: npm run documentation
 
       - name: Deploy to GitHub Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs
           branch: master


### PR DESCRIPTION
*Description of changes:*
The doc deployment action added in https://github.com/awslabs/diagram-maker/pull/111 is broken and this PR fixes it. The issue was the mixing of `uses` and `runs` at the same time. 

I also took the opportunity to refactor the action a bit and add move emojis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
